### PR TITLE
fix(node setup): fixed node setup to source instead.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,21 +109,21 @@ You are ready to go! The following configurations are avaialble.
 ### Python
 
 Installs Python, creates venv, installs global tools
-(why `source` first? When you source the file, you'll enter the newly created python ENV after completion. Otherwise, you'll just build it.
-(also, to exit out of a venv, type `deactivate`)
-)
+(why `source` first? When you source the file, you'll enter the newly created env. Otherwise, you'll just build it)
 
 ```bash
 cd toolshed;
 source setup_python_env.sh
 ```
+(To exit out of a venv, type `deactivate`)
 
 ### Node.js
 
 Installs Node via NVM and global npm tools defined in [`node-tools`](global-tools/node-tools.json)
 
 ```bash
-./setup-node-env.sh
+cd toolshed;
+source setup-node-env.sh
 ```
 
 ### Docker Cleanup

--- a/global-tools/node-tools.json
+++ b/global-tools/node-tools.json
@@ -8,7 +8,6 @@
     "typescript": "^5.4.5",
     "tsx": "^4.7.0",
     "commitizen": "4.3.0",
-    "cz-conventional-changelog": "3.3.0",
-    "jq": "^1.6.0"
+    "cz-conventional-changelog": "3.3.0"
   }
 }

--- a/setup-node-env.sh
+++ b/setup-node-env.sh
@@ -44,3 +44,9 @@ done
 # Show final list
 echo "📄 Final list of globally installed npm packages:"
 npm ls -g --depth=0
+
+# Write local .czrc to current directory
+echo "🛠 Writing global .czrc pointing to global adapter in $HOME/.czrc..."
+echo '{ "path": "cz-conventional-changelog" }' > "$HOME/.czrc"
+
+echo "✅ Bootstrapping complete! Run \`npx cz\` here to use the standard commit wizard."


### PR DESCRIPTION
Add standard commit to global

adding .czrc to $HOME for max reuse.   This way both node and python ENV can use standard commits